### PR TITLE
Get an Evented message value instead of the item. This closes #73.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install python-bluetooth -qq -y
+    - if [[ $TRAVIS_PYTHON_VERSION = '2.6' ]]; then pip install importlib; fi
     - pip install pyserial
     - pip install coveralls
 install: pip install -q -e .

--- a/openxc/tools/dashboard.py
+++ b/openxc/tools/dashboard.py
@@ -97,7 +97,7 @@ class DataPoint(object):
                 result = ""
                 for item, value in enumerate(self.measurement_type.states):
                     # TODO missing keys here?
-                    result += "%s: %s " % (value, self.events.get(item, "?"))
+                    result += "%s: %s " % (value, self.events.get(value, "?"))
                 value = result
 
             value_color = curses.color_pair(2)


### PR DESCRIPTION
New dashboard output looks like this:

![image](https://cloud.githubusercontent.com/assets/2513422/14612807/0609a740-054e-11e6-8bf4-546ded295921.png)

There's still an issue where there's not enough space to the left of the signal name for all the evented states. That's a bit more complicated to address and perhaps could be handled when the diagnostics messages are added.