### PR TITLE
Drop support for Python 2.6, pin version of pyserial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install python-bluetooth -qq -y
-    - if [[ $TRAVIS_PYTHON_VERSION = '2.6' ]]; then pip install importlib; fi
-    - pip install pyserial
+    - pip install pyserial==3.1.1
     - pip install coveralls
 install: pip install -q -e .
 script: python setup.py test

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 OpenXC Python Library Changelog
 ===============================
 
+v0.14.0-dev
+----------
+
+* Remove support for Python 2.6
+
 v0.13.0
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ OpenXC for Python
     :target: http://python.openxcplatform.com
     :alt: Documentation Status
 
-The OpenXC Python library (for Python 2.6 or 2.7) provides an interface to
+The OpenXC Python library (for Python 2.7) provides an interface to
 vehicle data from the OpenXC Platform. The primary platform for OpenXC
 applications is Android, but for prototyping and testing, often it is
 preferrable to use a low-overhead environment like Python when developing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ OpenXC for Python
 :Documentation: http://python.openxcplatform.com
 :Source: http://github.com/openxc/openxc-python/
 
-The OpenXC Python library (for Python 2.6 or 2.7) provides an interface to
+The OpenXC Python library (for Python 2.7) provides an interface to
 vehicle data from the OpenXC Platform. The primary platform for OpenXC
 applications is Android, but for prototyping and testing, often it is
 preferrable to use a low-overhead environment like Python when developing.
@@ -19,7 +19,7 @@ In addition to a port of the Android library API, the package also contains a
 number of command-line tools for connecting to the vehicle interface and
 manipulating previously recorded vehicle data.
 
-This Python package works with Python 2.6 and 2.7. Unfortunately we had to drop
+This Python package works with Python 2.7. Unfortunately we had to drop
 support for Python 3 when we added the protobuf library as a dependency.
 
 For general documentation on the OpenXC platform, visit the main `OpenXC site`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Install Python and Pip
 ----------------------
 
 This library (obviously) requires a Python language runtime - the OpenXC library
-currently works with Python 2.6 and 2.7, but not Python 3.x.
+currently works with Python 2.7, but not Python 3.x.
 
 - **Mac OS X and Linux**
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='openxc',
     tests_require=['nose'],
     install_requires=install_reqs,
     extras_require = {
-        'serial': ["pyserial"],
+        'serial': ["pyserial==3.1.1"],
         'bluetooth': ["pybluez"],
         'lxml': ["lxml"],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27
+envlist = py27
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
pyserial no longer supports Python 2.6 (perhaps unintentionally - it is
using Python 2.7+ style string formatting as of v3.1.1). In the
interesting of looking to the future, we will use this opportunity to
drop support for Python 2.6.

Fixes #79.