### PR TITLE
View Diagnostic Responses

### DIFF
--- a/openxc/tools/static/js/dashboard.js
+++ b/openxc/tools/static/js/dashboard.js
@@ -221,7 +221,7 @@ function addDiagnosticResponse(name, message) {
 		text: message.value
 	}).appendTo('#' + name);
 
-	if (msg.success == false) {
+	if (message.success == false) {
 		$('<td/>', {
 			id: name + '_neg_resp_code',
 			text: message.negative_response_code

--- a/openxc/tools/templates/dashboard.html
+++ b/openxc/tools/templates/dashboard.html
@@ -40,6 +40,21 @@
                 <input id="dashboardSettingsSubmitBtn" type="submit" value="Update" onclick="return validateSettingsForm();">
             </form>
         </div>
+        <div>
+            <table id="diagnostic">
+                <caption>Diagnostic Responses</caption>
+                <tr>
+                    <th>Bus</th>
+                    <th>ID</th>
+                    <th>Mode</th>
+                    <th>PID</th>
+                    <th>Success</th>
+                    <th>Payload</th>
+                    <th>Value</th>
+                    <th>Neg. Resp. Code</th>
+                </tr>
+            </table>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
### Changes
- Added table to view diagnostic response information in the dashboard

### Related Issue
- #48 

### Diagnostic Requests Tested
- True Request: `openxc-diag --message 0x7d0 --mode 0x22 --pid 0xd100 add`
- False Request: `openxc-diag --message 0x7d0 --mode 0x1 --pid 0xc add`