### PR TITLE
Fix Auto-Detect Bug & Platform Command (Protobuf)

### DIFF
--- a/openxc/formats/binary.py
+++ b/openxc/formats/binary.py
@@ -91,6 +91,8 @@ class ProtobufFormatter(object):
             return openxc_pb2.ControlCommand.PAYLOAD_FORMAT
         elif command_name == "predefined_obd2":
             return openxc_pb2.ControlCommand.PREDEFINED_OBD2_REQUESTS
+        elif command_name == "platform":
+            return openxc_pb2.ControlCommand.PLATFORM
         else:
             raise UnrecognizedBinaryCommandError(command_name)
 
@@ -321,6 +323,8 @@ class ProtobufFormatter(object):
                     parsed_message['command_response'] = "af_bypass"
                 elif response.type == openxc_pb2.ControlCommand.PREDEFINED_OBD2_REQUESTS:
                     parsed_message['command_response'] = "predefined_obd2"
+                elif response.type == openxc_pb2.ControlCommand.PLATFORM:
+                    parsed_message['command_response'] = "platform"
                 else:
                     raise UnrecognizedBinaryCommandError(response.type)
 

--- a/openxc/sources/base.py
+++ b/openxc/sources/base.py
@@ -39,7 +39,7 @@ class DataSource(threading.Thread):
         self.running = True
         self._streamer = None
         self._formatter = None
-        self.format = payload_format
+        self._format = payload_format
 
         self.logger = SourceLogger(self, log_mode)
 


### PR DESCRIPTION
### Changes
- Added `openxc-control platform` command to Protobuf format
- Fixed variable naming which was causing issues with the auto-detect and switching between JSON and Protobuf formats