### PR TITLE
Update .gitignore For SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.xml
 diffcover.html
 htmlcov
 *~
+.scannerwork/


### PR DESCRIPTION
### Changes
- Update .gitignore to ignore `.scannerwork` folder