### PR TITLE
Fix OBD2Scanner Command Output

### DIFF
--- a/openxc/tools/obd2scanner.py
+++ b/openxc/tools/obd2scanner.py
@@ -6,7 +6,7 @@ program.
 module are internal only.
 """
 
-
+import sys
 import argparse
 
 from .common import device_options, configure_logging, select_device
@@ -24,11 +24,11 @@ def scan(controller, bus=None):
             for item in response[1]:
                 if 'success' in item:
                     no_response = False
-                    print(("PID 0x%x responded with: %s" % (pid, item)))
+                    print("PID 0x%x responded with: %s" % (pid, item))
 
             if (no_response == True):
-                print(("PID 0x%x did not respond" % pid))
-
+                print("PID 0x%x did not respond" % pid)
+        sys.stdout.flush()
 
 def parse_options():
     parser = argparse.ArgumentParser(description="Send requests for all "

--- a/openxc/tools/obd2scanner.py
+++ b/openxc/tools/obd2scanner.py
@@ -18,8 +18,7 @@ def scan(controller, bus=None):
     # what the vehicle reports that it *should* support.
     print("Beginning sequential scan of all OBD-II PIDs")
     for pid in range(0, 0x88):
-            response = controller.create_diagnostic_request(0x7df, mode=0x1, bus=bus,
-                    wait_for_first_response=True, pid=pid)
+        response = controller.create_diagnostic_request(0x7df, mode=0x1, bus=bus, wait_for_first_response=True, pid=pid)
         if response is not None:
             no_response = True
             for item in response[1]:


### PR DESCRIPTION
### Changes
- Flush `stdout` after print statements
- Fixed bug where scanner wouldn't work due to wrong indentation in the scanner's for-loop

### Notes
On MinTTY, print statements were buffered so output would only show after ~40 lines. By flushing the standard output in the scanner's for-loop, the console now prints each line as it is registered.