### PR TITLE
SonarQube - Reduce Complexity

### DIFF
--- a/openxc/formats/binary.py
+++ b/openxc/formats/binary.py
@@ -96,28 +96,28 @@ class ProtobufFormatter(object):
             raise UnrecognizedBinaryCommandError(command_name)
 
     @classmethod
-    def _handle_passthrough_control_command(cls, data, message):
+    def _handle_passthrough_cc_message(cls, data, message):
         message.control_command.passthrough_mode_request.bus = data['bus']
         message.control_command.passthrough_mode_request.enabled = data['enabled']
 
     @classmethod
-    def _handle_acceptance_filter_bypass_control_command(cls, data, message):
+    def _handle_acceptance_filter_bypass_cc_message(cls, data, message):
         message.control_command.acceptance_filter_bypass_command.bus = data['bus']
         message.control_command.acceptance_filter_bypass_command.bypass = data['bypass']
 
     @classmethod
-    def _handle_predefined_obd2_requests_control_command(cls, data, message):
+    def _handle_predefined_obd2_requests_cc_message(cls, data, message):
         message.control_command.predefined_obd2_requests_command.enabled = data['enabled']
 
     @classmethod
-    def _handle_payload_format_control_command(cls, data, message):
+    def _handle_payload_format_cc_message(cls, data, message):
         if data['format'] == "json":
             message.control_command.payload_format_command.format = openxc_pb2.PayloadFormatCommand.JSON
         elif data['format'] == "protobuf":
             message.control_command.payload_format_command.format = openxc_pb2.PayloadFormatCommand.PROTOBUF
 
     @classmethod
-    def _handle_diagnostic_control_command(cls, data, message):
+    def _handle_diagnostic_cc_message(cls, data, message):
         request_command = message.control_command.diagnostic_request
         action = data['action']
         if action == "add":

--- a/openxc/formats/binary.py
+++ b/openxc/formats/binary.py
@@ -151,9 +151,9 @@ class ProtobufFormatter(object):
             message.can_message.bus = data['bus']
         if 'frame_format' in data:
             if data['frame_format'] == "standard":
-                message.can_message.frame_format = openxc_pb2.RawMessage.STANDARD
+                message.can_message.frame_format = openxc_pb2.CanMessage.STANDARD
             elif data['frame_format'] == "extended":
-                message.can_message.frame_format = openxc_pb2.RawMessage.EXTENDED
+                message.can_message.frame_format = openxc_pb2.CanMessage.EXTENDED
         message.can_message.id = data['id']
         message.can_message.data = binascii.unhexlify(data['data'].split('0x')[1])
 
@@ -233,9 +233,9 @@ class ProtobufFormatter(object):
                 if can_message.HasField('data'):
                     parsed_message['data'] = "0x%s" % binascii.hexlify(can_message.data).decode("ascii")
                 if can_message.HasField('frame_format'):
-                    if can_message.frame_format == openxc_pb2.RawMessage.STANDARD:
+                    if can_message.frame_format == openxc_pb2.CanMessage.STANDARD:
                         parsed_message['frame_format'] = "standard"
-                    elif can_message.frame_format == openxc_pb2.RawMessage.EXTENDED:
+                    elif can_message.frame_format == openxc_pb2.CanMessage.EXTENDED:
                         parsed_message['frame_format'] = "extended"
             elif message.type == message.DIAGNOSTIC:
                 diagnostic_message = message.diagnostic_response

--- a/openxc/formats/binary.py
+++ b/openxc/formats/binary.py
@@ -146,15 +146,15 @@ class ProtobufFormatter(object):
         message.type = openxc_pb2.VehicleMessage.CONTROL_COMMAND
         message.control_command.type = cls._command_string_to_protobuf(command_name)
         if message.control_command.type == openxc_pb2.ControlCommand.PASSTHROUGH:
-            cls._handle_passthrough_control_command(data, message)
+            cls._handle_passthrough_cc_message(data, message)
         elif message.control_command.type == openxc_pb2.ControlCommand.ACCEPTANCE_FILTER_BYPASS:
-            cls._handle_acceptance_filter_bypass_control_command(data, message)
+            cls._handle_acceptance_filter_bypass_cc_message(data, message)
         elif message.control_command.type == openxc_pb2.ControlCommand.PREDEFINED_OBD2_REQUESTS:
-            cls._handle_predefined_obd2_requests_control_command(data, message)
+            cls._handle_predefined_obd2_requests_cc_message(data, message)
         elif message.control_command.type == openxc_pb2.ControlCommand.PAYLOAD_FORMAT:
-            cls._handle_payload_format_control_command(data, message)
+            cls._handle_payload_format_cc_message(data, message)
         elif message.control_command.type == openxc_pb2.ControlCommand.DIAGNOSTIC:
-            cls._handle_diagnostic_control_command(data, message)
+            cls._handle_diagnostic_cc_message(data, message)
 
     @classmethod
     def _build_command_response_message(cls, data, message):

--- a/openxc/generator/structures.py
+++ b/openxc/generator/structures.py
@@ -100,17 +100,7 @@ class Message(object):
                 value = int(value, 0)
             self._id = value
 
-    def merge_message(self, data):
-        self.bus_name = self.bus_name or data.get('bus', None)
-
-        message_attributes = dir(self)
-        message_attributes = [a.replace('bus_name', 'bus') for a in message_attributes]
-        data_attributes = list(data.keys())
-        extra_attributes = set(data_attributes) - set(message_attributes)
-
-        if extra_attributes:
-            fatal_error('ERROR: Message %s has unrecognized attributes: %s' % (data.get('id'), ', '.join(extra_attributes)))
-
+    def validate_bus(self):
         if getattr(self, 'message_set'):
             self.bus = self.message_set.lookup_bus(name=self.bus_name)
             if not self.bus.valid():
@@ -122,6 +112,19 @@ class Message(object):
                 else:
                     msg = "Bus '%s' is disabled" % self.bus_name
                 LOG.warning("%s - message 0x%x will be disabled" % (msg, self.id))
+
+    def merge_message(self, data):
+        self.bus_name = self.bus_name or data.get('bus', None)
+
+        message_attributes = dir(self)
+        message_attributes = [a.replace('bus_name', 'bus') for a in message_attributes]
+        data_attributes = list(data.keys())
+        extra_attributes = set(data_attributes) - set(message_attributes)
+
+        if extra_attributes:
+            fatal_error('ERROR: Message %s has unrecognized attributes: %s' % (data.get('id'), ', '.join(extra_attributes)))
+
+        self.validate_bus()
 
         self.id = self.id or data.get('id')
         self.name = self.name or data.get('name', None)

--- a/openxc/tools/control.py
+++ b/openxc/tools/control.py
@@ -162,25 +162,24 @@ def main():
             set_rtc_time(interface, int(arguments.unix_time))
         if arguments.host is not None:
             modem_configuration(interface, arguments.host, arguments.port)
-    elif arguments.command.startswith("write"):
-        if arguments.command == "write":
-            if arguments.write_name:
-                interface.write(name=arguments.write_name,
-                        value=arguments.write_value,
-                        event=arguments.write_event)
-            elif arguments.write_id:
-                if not arguments.write_data:
-                    sys.exit("%s requires an id and data" % arguments.command)
-                # TODO we should use unhexlify as with the diagnostic command
-                # payloads so we can standardize the API and not deal with hex
-                # strings in code
-                interface.write(bus=int(arguments.bus),
-                        id=arguments.write_id,
-                        data=arguments.write_data,
-                        frame_format=arguments.write_frame_format)
-            elif arguments.write_input_file:
-                write_file(interface, arguments.write_input_file)
-            else:
-                sys.exit("%s requires a signal name, message ID or filename" % arguments.command)
+    elif arguments.command == "write":
+        if arguments.write_name:
+            interface.write(name=arguments.write_name,
+                    value=arguments.write_value,
+                    event=arguments.write_event)
+        elif arguments.write_id:
+            if not arguments.write_data:
+                sys.exit("%s requires an id and data" % arguments.command)
+            # TODO we should use unhexlify as with the diagnostic command
+            # payloads so we can standardize the API and not deal with hex
+            # strings in code
+            interface.write(bus=int(arguments.bus),
+                    id=arguments.write_id,
+                    data=arguments.write_data,
+                    frame_format=arguments.write_frame_format)
+        elif arguments.write_input_file:
+            write_file(interface, arguments.write_input_file)
+        else:
+            sys.exit("%s requires a signal name, message ID or filename" % arguments.command)
     else:
         print(("Unrecognized command \"%s\"" % arguments.command))

--- a/openxc/tools/diagnostics.py
+++ b/openxc/tools/diagnostics.py
@@ -13,6 +13,23 @@ import time
 
 from .common import device_options, configure_logging, select_device
 
+def print_diagnostic_response(responses):
+    for response in responses:
+        # After sending a diagnostic request, it will return with a signal message saying if the
+        # request was recieved. After that it used to show about 30 vehicle messages (rpm, speed, etc)
+        # with the actual diagnostic response mixed in. So, if the response length is more than
+        # 1, it's the response, if its less (only 1) it's the recieved message.
+        if len(response) > 1:
+            # Stripping all of the unnesseary data we get after sending a diag request in python
+            # Just like in enabler, it's a diag response if it contains the keys "mode", "bus", 
+            # "id", and "success". 
+            diag_mgs_req_keys = ['mode', 'bus', 'id', 'success']
+            indices = [i for i, s in enumerate(response) if all(x in s for x in diag_mgs_req_keys)]
+            if indices:
+                print(("Response: %s" % response[indices[0]]))
+        else:
+            print(("Response: %s" % response))
+
 def diagnostic_request(arguments, controller):
     message = int(arguments.message, 0)
     mode = int(arguments.mode, 0)
@@ -40,21 +57,7 @@ def diagnostic_request(arguments, controller):
         if len(responses) == 0:
             print("No response received before timeout")
         else: 
-            for response in responses:
-                # After sending a diagnostic request, it will return with a signal message saying if the
-                # request was recieved. After that it used to show about 30 vehicle messages (rpm, speed, etc)
-                # with the actual diagnostic response mixed in. So, if the response length is more than
-                # 1, it's the response, if its less (only 1) it's the recieved message.
-                if len(response) > 1:
-                    # Stripping all of the unnesseary data we get after sending a diag request in python
-                    # Just like in enabler, it's a diag response if it contains the keys "mode", "bus", 
-                    # "id", and "success". 
-                    diag_mgs_req_keys = ['mode', 'bus', 'id', 'success']
-                    indices = [i for i, s in enumerate(response) if all(x in s for x in diag_mgs_req_keys)]
-                    if indices:
-                        print(("Response: %s" % response[indices[0]]))
-                else:
-                    print(("Response: %s" % response))
+            print_diagnostic_response(responses)
     elif arguments.command == "cancel":
         if controller.delete_diagnostic_request(message, mode, bus=bus,
                 pid=pid):


### PR DESCRIPTION
### Changes
- Resolve SonarQube code smells
- Extracted smaller methods from multiple files to reduce the complexity of larger methods
    - 3 methods were left alone because extracting methods would have reduce readability or there was no logical grouping of lines to extract
- Replaced references to `RawMessage` with `CanMessage`
    - `RawMessage` was deprecated in the Protobuf definition a while back