### PR TITLE
Flush After Print Statements

### DIFF
--- a/openxc/tools/dump.py
+++ b/openxc/tools/dump.py
@@ -13,6 +13,9 @@ import logging
 from openxc.formats.json import JsonFormatter
 from .common import device_options, configure_logging, select_device
 
+import functools
+print = functools.partial(print, flush=True)
+
 def receive(message, **kwargs):
     message['timestamp'] = time.time()
     print((JsonFormatter.serialize(message)))

--- a/openxc/tools/obd2scanner.py
+++ b/openxc/tools/obd2scanner.py
@@ -12,6 +12,9 @@ import argparse
 from .common import device_options, configure_logging, select_device
 import json
 
+import functools
+print = functools.partial(print, flush=True)
+
 def scan(controller, bus=None):
 
     # TODO could read the response from the "PIDs supported" requests to see
@@ -28,7 +31,6 @@ def scan(controller, bus=None):
 
             if (no_response == True):
                 print("PID 0x%x did not respond" % pid)
-        sys.stdout.flush()
 
 def parse_options():
     parser = argparse.ArgumentParser(description="Send requests for all "

--- a/openxc/tools/scanner.py
+++ b/openxc/tools/scanner.py
@@ -12,6 +12,9 @@ from collections import defaultdict
 
 from .common import device_options, configure_logging, select_device
 
+import functools
+print = functools.partial(print, flush=True)
+
 TESTER_PRESENT_MODE = 0x3e
 TESTER_PRESENT_PAYLOAD = bytearray([0])
 


### PR DESCRIPTION
### Changes
- Create function for print with `flush` set to `true`
- Applies to `openxc-obd2scanner`, `openxc-scanner`, and `openxc-dump`