### PR TITLE
Add a try catch for keyboardinterupt for both openxc-dump and scanner…

### DIFF
--- a/openxc/tools/dump.py
+++ b/openxc/tools/dump.py
@@ -9,6 +9,7 @@ module are internal only.
 import argparse
 import time
 import logging
+import sys
 
 from openxc.formats.json import JsonFormatter
 from .common import device_options, configure_logging, select_device
@@ -31,11 +32,14 @@ def parse_options():
 
 
 def main():
-    configure_logging(logging.DEBUG)
-    arguments = parse_options()
-
-    source_class, source_kwargs = select_device(arguments)
-    source = source_class(callback=receive, **source_kwargs)
-    source.start()
-    # TODO test this, I'd prefer it to the sleep loop
-    source.join()
+    try:
+        configure_logging(logging.DEBUG)
+        arguments = parse_options()
+        source_class, source_kwargs = select_device(arguments)
+        source = source_class(callback=receive, **source_kwargs)
+        source.start()
+        # TODO test this, I'd prefer it to the sleep loop
+        while(True):
+            source.join(0.1)
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/openxc/tools/scanner.py
+++ b/openxc/tools/scanner.py
@@ -6,7 +6,7 @@ program.
 module are internal only.
 """
 
-
+import sys
 import argparse
 from collections import defaultdict
 
@@ -98,11 +98,14 @@ def parse_options():
 
 
 def main():
-    configure_logging()
-    arguments = parse_options()
+    try:
+        configure_logging()
+        arguments = parse_options()
 
-    controller_class, controller_kwargs = select_device(arguments)
-    controller = controller_class(**controller_kwargs)
-    controller.start()
-
-    scan(controller, arguments.bus, arguments.message_id)
+        controller_class, controller_kwargs = select_device(arguments)
+        controller = controller_class(**controller_kwargs)
+        controller.start()
+        while(True):
+            scan(controller, arguments.bus, arguments.message_id)
+    except KeyboardInterrupt:
+        sys.exit(0)


### PR DESCRIPTION
… tools.

Update the main() function to catch ctrl-c keyboard interrupt for openxc-dump and openxc-scanner.

Handles errors for the keyboard interrupt for expected behavior to end tool threads. 